### PR TITLE
Improve the output

### DIFF
--- a/TeamCityFormatter.php
+++ b/TeamCityFormatter.php
@@ -96,6 +96,12 @@ class TeamCityFormatter implements FormatterInterface
 			if ( true === isset($metaParams) && true === is_array($metaParams) ) {
 				$this->printEvent('testMetadata', $metaParams );	
 			}
+			exec( 'tail -n1 /tmp/php-errors', $php_errors );
+			$this->printEvent('testMetadata', array(
+				'testName' => $testName,
+				'name'     => 'errorLog',
+				'value'    => join( "\n", $php_errors ),
+			));
         } elseif ($event->getResult() == StepEvent::PENDING) {
             $this->printEvent('testIgnored', $params);
         } elseif ($event->getResult() == StepEvent::SKIPPED) {

--- a/TeamCityFormatter.php
+++ b/TeamCityFormatter.php
@@ -233,6 +233,9 @@ class TeamCityFormatter implements FormatterInterface
  	 */
 	public static function escapeValue($text)
 	{
+		if ( true === empty($text) || null === $text ) {
+			$text = 'null';	
+		}
 		return \str_replace(
 			['|', "'", "\n", "\r", ']', '['],
 			['||', "|'", '|n', '|r', '|]', '|['],

--- a/TeamCityFormatter.php
+++ b/TeamCityFormatter.php
@@ -180,7 +180,8 @@ class TeamCityFormatter implements FormatterInterface
     {
         self::printText("\n##teamcity[$eventName");
         foreach ($params as $key => $value) {
-            self::printText(" $key='$value'");
+			$escapedValue = self::escapeValue( (string) $value );
+            self::printText(" $key='$escapedValue'");
         }
         self::printText("]\n");
     }
@@ -192,4 +193,17 @@ class TeamCityFormatter implements FormatterInterface
     {
         file_put_contents('php://stderr', $text);
     }
+
+	/**
+ 	 * @param string $text
+ 	 * @return string Properly escaped input.
+ 	 */
+	public static function escapeValue($text)
+	{
+		return \str_replace(
+			['|', "'", "\n", "\r", ']', '['],
+			['||', "|'", '|n', '|r', '|]', '|['],
+			$text
+		);
+	}
 }


### PR DESCRIPTION
Add expected and actual values data to failed steps, properly escapes those, and adds the last line of the error log, as well as the used command, to test metadata