### PR TITLE
Disable the beforeStep event

### DIFF
--- a/src/TeamCityFormatter.php
+++ b/src/TeamCityFormatter.php
@@ -38,7 +38,7 @@ class TeamCityFormatter implements FormatterInterface
     {
         $events = array(
             'afterStep',
-            'beforeStep',
+            //'beforeStep',
             'beforeFeature', 'afterFeature',
             'beforeScenario', 'afterScenario',
 //            'beforeSuite', 'afterSuite',


### PR DESCRIPTION
Since it breaks the formatting in TC. It might actually be better to add it as test meta at some point.