### PR TITLE
Capture extra lines in the message as STDOUT

### DIFF
--- a/src/TeamCityFormatter.php
+++ b/src/TeamCityFormatter.php
@@ -77,9 +77,12 @@ class TeamCityFormatter implements FormatterInterface
 					$params['type'] = 'comparisonFailure';
 					$params['expected'] = $step->getText() . ' ' . (string) $arg;
 					$output = explode( "\n", $event->getException()->getMessage() );
-					$command = $output[0];
-					$stdout = $output[1];
-					$stderr = $output[2];
+					$command = array_shift( $output ); // Is always the first element.
+					$exit_status = array_pop( $output ); // Is always the last one.
+					$cwd = array_pop( $output ); // Is just before the exit status.
+					// Going backwards, next one (or more?) is STDERR. Let's pretend, for now, that it's a single line.
+					$stderr = array_pop( $output );
+					$stdout = join( "\n", $output ); // Let's presume that any extra rows are the STDOUT.
 					if ( false !== strpos( $step->getText(), 'STDOUT' ) ) {
 						$params['actual'] = $stdout;
 					} else if ( false !== strpos( $step->getText(), 'STDERR' ) ) {


### PR DESCRIPTION
Since the Exception's message does not name the array keys, and since STDOUT (as well as STDERR) may contain multiple lines, we can't simply reference individual positions. But there are some known positions which we can take advantage of, in order to make our way to multiple lines of STDOUT.

First one is the command. The last one is the exit status, the one before exit status is cwd, and what's left is a mix of STDOUT and STDERR. For now, let's presume, that STDERR is a single line, while the rest is STDOUT.